### PR TITLE
Switch build to CircleCI, facilitate automated publishing to NPM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7.10
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+        
+      # run tests!
+      - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,21 @@ jobs:
         
       # run tests!
       - run: yarn test
+
+      - run:
+          name: Authenticate to NPM
+          command: |
+            # See: http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+            # Verify that the authentication works
+            npm whoami
+
+      - deploy:
+          name: Publish to NPM on tag
+          command: |
+            # If we aren't on a tagged release, this deploymnt does not run.
+            if [ -z "$CIRCLE_TAG" ]; then
+              exit 0
+            fi
+
+            npm publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
         
+      - run: yarn prepublish
+
       # run tests!
       - run: yarn test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - 8.9
-before_script:
-  - npm install -g grunt-cli
-env:
-  global:
-    - secure: DfzCbO0kAVDhseVlcdqyqZPprWXiqmnYUbXaaD5JJtHL/j5GzJsBsSNynibXSYL+cGRKuCQZlDT5pYtWDyaJjc6OQ+tUFHFYYB3P4H/4mIJWGU8TgiFMRbBh/tD8Q/qiaEieONWy/r9EiIdXXxyGd8z3QvBAyfoPQFUCw0sCeN4=
-    - secure: TdDrCzzTLxzeTwAJ/TfWb+pJpUi1IOGGEmVhjh79xpodGWCa1YViHU2alDNoAEDb9aMOqzFNXQYvmy68lI3nl+zEiITje2y7jX1de3K3nn73y07xBDJ1o+ZclJmeZxhRcAAxSsJOLDO4muZJctjcdCXFVqWYHDqoynPHTyCJR5A=

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HTML Highlighter
 
+[![CircleCI](https://circleci.com/gh/dossier/html-highlighter.svg?style=svg)](https://circleci.com/gh/dossier/html-highlighter)
+
 The HTML Highlighter is a JavaScript module that solves these problems:
 
  1. Display colorful highlights on words in a live Web page that are

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "Html Highlighter",
   "description": "Highlight and select phrases in HTML pages.",
   "version": "0.1.3",
-  "main": "dist/html_highlighter.min.js",
+  "main": "dist/html_highlighter.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dossier/html-highlighter.git"
@@ -18,8 +18,9 @@
     "url": "https://github.com/dossier/html-highlighter.git/issues"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack --progress --color --display-error-details",
-    "build:dev": "webpack --progress --color --display-error-details",
+    "build": "webpack --progress --color --display-error-details",
+    "build:min": "NODE_ENV=production webpack --progress --color --display-error-details",
+    "prepublish": "yarn run build && yarn run build:min",
     "start": "webpack-dev-server --progress --color --content-base dist/ --hot --inline --hot --host 0.0.0.0 --port $([ -z \"$NODE_PORT\" ] && echo 8080 || echo $NODE_PORT)",
     "start:watch": "webpack --progress --color --display-error-details --watch",
     "test": "mocha-webpack --colors --webpack-config webpack.config-test.js 'test/start.js'",
@@ -31,6 +32,9 @@
     "check-fmt:json": "sh/check-fmt:json",
     "check-fmt": "sh/check-fmt:js && sh/check-fmt:json"
   },
+  "files": [
+    "dist/*"
+  ],
   "dependencies": {
     "merge": "^1.2.0"
   },


### PR DESCRIPTION
This PR should smooth out the process of publishing to NPM and make use of this package as a library easier.

In a future commit, once this is on master, I'm going to try the `npm version` command: https://docs.npmjs.com/cli/version, which should trigger the push to NPM.