### PR TITLE
Backwards-compatible call to `scrollTo`

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -124,7 +124,7 @@ function scrollIntoView(el: HTMLElement, container: any): void {
   }
 
   const bbox = el.getBoundingClientRect();
-  container.scrollTo({ top: bbox.top + containerTop - (containerHeight - bbox.height) / 2 });
+  container.scrollTo(window.scrollX, bbox.top + containerTop - (containerHeight - bbox.height) / 2);
 }
 
 // Export "private" functions so they too can be tested.


### PR DESCRIPTION
Chrome 36 requires two parameters to be specified to the `scrollTo` method,
otherwise it throws an exception.